### PR TITLE
Fix issue with includeDrafts column not being created on fresh install.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.1.1 - 2023
+
+- Fixed issue with includeDrafts column not being created on fresh install.
+
 ## 2.1.0 - 2023
 
 - Added ability to include drafts in results.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 Add the following to your composer.json requirements. Be sure to adjust the version number to match the version you wish to install.
 
 ```
-"masugadesign/cpfilters": "2.1.0",
+"masugadesign/cpfilters": "2.1.1",
 ```
 
 ### Config

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "handle": "cpfilters",
     "name": "CP Filters",
     "developer": "Masuga Design",
-    "schemaVersion": "2.1.0",
+    "schemaVersion": "2.1.1",
     "developerUrl": "https://gomasuga.com",
     "changelogUrl": "https://raw.githubusercontent.com/masugadesign/cp-filters-craft-cms/master/CHANGELOG.md",
 	"class": "Masuga\\CpFilters\\CpFilters"

--- a/src/migrations/Install.php
+++ b/src/migrations/Install.php
@@ -12,6 +12,7 @@ class Install extends Migration
 				'id' => $this->primaryKey(),
 				'userId' => $this->integer(),
 				'title' => $this->string(255),
+				'includeDrafts' => $this->string(10),
 				'filterElementType' => $this->string(255),
 				'filterGroupId' => $this->integer(),
 				'filterCriteria' => $this->text(),


### PR DESCRIPTION
On fresh install, clicking through to saved filters would throw an error complaining about the CPFilter table not having an includeDrafts column.

This PR fixes that issue.